### PR TITLE
Fix `E0308` to compile on apple hardware

### DIFF
--- a/src/cap.rs
+++ b/src/cap.rs
@@ -32,7 +32,7 @@ use tokio::runtime::Handle;
 #[cfg(unix)]
 fn read_only(mut permissions: Permissions) -> Permissions {
   // Remove user write permissions.
-  let () = permissions.set_mode(permissions.mode() & !S_IWUSR);
+  let () = permissions.set_mode(permissions.mode() & !S_IWUSR as u32);
   permissions
 }
 
@@ -47,7 +47,7 @@ fn read_only(mut permissions: Permissions) -> Permissions {
 #[cfg(unix)]
 fn writeable(mut permissions: Permissions) -> Permissions {
   // Set user write permissions.
-  let () = permissions.set_mode(permissions.mode() | S_IWUSR);
+  let () = permissions.set_mode(permissions.mode() | S_IWUSR as u32);
   permissions
 }
 

--- a/src/cap.rs
+++ b/src/cap.rs
@@ -32,6 +32,7 @@ use tokio::runtime::Handle;
 #[cfg(unix)]
 fn read_only(mut permissions: Permissions) -> Permissions {
   // Remove user write permissions.
+  #[allow(trivial_numeric_casts)] // S_IWUSR is u16 on some platforms (#7)
   let () = permissions.set_mode(permissions.mode() & !S_IWUSR as u32);
   permissions
 }
@@ -47,6 +48,7 @@ fn read_only(mut permissions: Permissions) -> Permissions {
 #[cfg(unix)]
 fn writeable(mut permissions: Permissions) -> Permissions {
   // Set user write permissions.
+  #[allow(trivial_numeric_casts)] // S_IWUSR is u16 on some platforms (#7)
   let () = permissions.set_mode(permissions.mode() | S_IWUSR as u32);
   permissions
 }


### PR DESCRIPTION
Thanks for creating this cool project.
I was trying to run it on a MacBook, but it appears some platform specific issue prevent `notnow` to compile, at least on BSD-like hardware

P.s. I tried with both Rust `1.65.0` and `stable` tool chain.

https://app.warp.dev/block/oxnzmhlai0gfhR8PHIBNXR
```
$ cargo build

   Compiling notnow v0.3.4 (/Users/ychou/choznerol/contrib/notnow)
error[E0308]: mismatched types
  --> src/cap.rs:35:54
   |
35 |   let () = permissions.set_mode(permissions.mode() & !S_IWUSR);
   |                                                      ^^^^^^^^ expected `u32`, found `u16`

error[E0277]: no implementation for `u32 & u16`
  --> src/cap.rs:35:52
   |
35 |   let () = permissions.set_mode(permissions.mode() & !S_IWUSR);
   |                                                    ^ no implementation for `u32 & u16`
   |
   = help: the trait `BitAnd<u16>` is not implemented for `u32`
   = help: the following other types implement trait `BitAnd<Rhs>`:
             <&'a i128 as BitAnd<i128>>
             <&'a i16 as BitAnd<i16>>
             <&'a i32 as BitAnd<i32>>
             <&'a i64 as BitAnd<i64>>
             <&'a i8 as BitAnd<i8>>
             <&'a isize as BitAnd<isize>>
             <&'a u128 as BitAnd<u128>>
             <&'a u16 as BitAnd<u16>>
           and 40 others

error[E0308]: mismatched types
  --> src/cap.rs:50:54
   |
50 |   let () = permissions.set_mode(permissions.mode() | S_IWUSR);
   |                                                      ^^^^^^^ expected `u32`, found `u16`

error[E0277]: no implementation for `u32 | u16`
  --> src/cap.rs:50:52
   |
50 |   let () = permissions.set_mode(permissions.mode() | S_IWUSR);
   |                                                    ^ no implementation for `u32 | u16`
   |
   = help: the trait `BitOr<u16>` is not implemented for `u32`
   = help: the following other types implement trait `BitOr<Rhs>`:
             <&'a i128 as BitOr<i128>>
             <&'a i16 as BitOr<i16>>
             <&'a i32 as BitOr<i32>>
             <&'a i64 as BitOr<i64>>
             <&'a i8 as BitOr<i8>>
             <&'a isize as BitOr<isize>>
             <&'a u128 as BitOr<u128>>
             <&'a u16 as BitOr<u16>>
           and 52 others

Some errors have detailed explanations: E0277, E0308.
For more information about an error, try `rustc --explain E0277`.
error: could not compile `notnow` due to 4 previous errors
```

`S_IWUSR` is of type `mode_t`:

https://github.com/rust-lang/libc/blob/d80e8bd3056d82fec80c022819084bdb0be3bdaa/src/unix/bsd/apple/mod.rs#L2928

On Linux, which is currently tested in CI, `mode_t` is `u32`:

https://github.com/rust-lang/libc/blob/d80e8bd3056d82fec80c022819084bdb0be3bdaa/src/unix/linux_like/linux/mod.rs#L6

On apple, `mode_t` is `u16`:

https://github.com/rust-lang/libc/blob/d80e8bd3056d82fec80c022819084bdb0be3bdaa/src/unix/bsd/apple/mod.rs#L11

https://github.com/search?q=repo%3Arust-lang%2Flibc+%22pub+type+mode_t+%3D+u16%22&type=code

With this change, both build and test passes on my MacBook. I can also help add `apple` to the CI metrix if it matches the project goal. 